### PR TITLE
Remove welcome text

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -30,14 +30,6 @@
             <div class="col-12 col-xl-10">
                 <div class="card shadow-sm">
                     <div class="card-body p-4">
-                        <h1 class="text-center mb-4">Welcome to the Demo Page</h1>
-                        <p class="text-muted text-center mb-2">
-                            This is a simple demo page created as an example. You can modify this template to suit your needs.
-                        </p>
-                        <p class="text-muted text-center mb-5">
-                            Feel free to add more content, styles, and functionality to make it your own!
-                        </p>
-
                         <div class="text-center mb-4 d-flex align-items-center justify-content-center">
                             <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 50 50" class="me-2">
                                 <circle cx="25" cy="25" r="23" fill="#f8981d" stroke="#000000" stroke-width="1"/>


### PR DESCRIPTION
This PR removes the welcome text and introductory paragraphs from the top of the page, making the interface cleaner and more focused on the NBA teams content.

Changes made:
- Removed "Welcome to the Demo Page" heading
- Removed two introductory paragraphs
- Kept the basketball icon and NBA Teams header
- Maintained all functionality including drag-and-drop

The page now starts directly with the NBA teams content, providing a more streamlined user experience.